### PR TITLE
[#138] fix NPE when closing the only open inspector/script view

### DIFF
--- a/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/AppContentView.java
+++ b/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/AppContentView.java
@@ -22,6 +22,7 @@ import com.aestallon.storageexplorer.swing.ui.commander.CommanderContainerView;
 import com.aestallon.storageexplorer.swing.ui.controller.SideBarController;
 import com.aestallon.storageexplorer.swing.ui.event.ArcScriptViewRenamed;
 import com.aestallon.storageexplorer.swing.ui.event.BreadCrumbsChanged;
+import com.aestallon.storageexplorer.swing.ui.event.TreeSelectionCeased;
 import com.aestallon.storageexplorer.swing.ui.misc.HiddenPaneSize;
 
 @Component
@@ -177,6 +178,11 @@ public class AppContentView extends JPanel {
   }
 
   @EventListener
+  public void onTreeSelectionCeased(final TreeSelectionCeased e) {
+    SwingUtilities.invokeLater(() -> breadCrumbs.set(null));
+  }
+
+  @EventListener
   public void onStorageEntryUserDataChanged(final StorageEntryUserDataChanged event) {
     breadCrumbs.refresh();
   }
@@ -266,6 +272,7 @@ public class AppContentView extends JPanel {
       elements.forEach(this::remove);
       elements.clear();
       if (path == null || path.length < 2) {
+        BreadCrumbs.this.revalidate();
         return;
       }
 

--- a/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/controller/SideBarController.java
+++ b/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/controller/SideBarController.java
@@ -133,7 +133,11 @@ public class SideBarController {
     if (!treeMayShow) {
       return;
     }
-    
+
+    if (treeContextByName.get(treeView.name()).toggleButton().isSelected()) {
+      return;
+    }
+
     treeContextByName.get(treeView.name()).toggleButton().setSelected(true);
     showTreeViewInternal(treeView);
   }
@@ -183,5 +187,12 @@ public class SideBarController {
         .map(it -> (TreeView) it)
         .ifPresent(tree -> tree.selectNode(locator.entityLocator()));
   }
+
+//  @EventListener
+//  public void clearTreeSelections(TreeSelectionCeased e) {
+//    SwingUtilities.invokeLater(() ->treeContextByName
+//        .values()
+//        .forEach(ctx -> ctx.treeView.clearSelection()));
+//  }
 
 }

--- a/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/event/TreeSelectionCeased.java
+++ b/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/event/TreeSelectionCeased.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2025 Szabolcs Bazil Papp
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.aestallon.storageexplorer.swing.ui.event;
+
+public record TreeSelectionCeased() {}

--- a/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/explorer/TabContainerView.java
+++ b/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/explorer/TabContainerView.java
@@ -36,6 +36,7 @@ import com.aestallon.storageexplorer.swing.ui.arcscript.ArcScriptController;
 import com.aestallon.storageexplorer.swing.ui.arcscript.editor.ArcScriptView;
 import com.aestallon.storageexplorer.swing.ui.arcscript.tree.ArcScriptSelectorTree;
 import com.aestallon.storageexplorer.swing.ui.event.ArcScriptViewRenamed;
+import com.aestallon.storageexplorer.swing.ui.event.TreeSelectionCeased;
 import com.aestallon.storageexplorer.swing.ui.inspector.InspectorView;
 import com.aestallon.storageexplorer.swing.ui.inspector.StorageEntryInspectorViewFactory;
 import com.aestallon.storageexplorer.swing.ui.misc.IconProvider;
@@ -61,6 +62,7 @@ public class TabContainerView extends JTabbedPane implements TabContainer {
     addChangeListener(e -> {
       final TabView selectedComponent = (TabView) getSelectedComponent();
       switch (selectedComponent) {
+        case null -> eventPublisher.publishEvent(new TreeSelectionCeased());
         case InspectorView<?> inspector -> eventPublisher.publishEvent(
             new TreeTouchRequest(inspector.storageEntry()));
         case ArcScriptView as -> eventPublisher.publishEvent(

--- a/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/tree/AbstractTreeView.java
+++ b/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/tree/AbstractTreeView.java
@@ -135,12 +135,12 @@ public abstract class AbstractTreeView
     treePathsByLeaf = new HashMap<>();
 
     add(scrollPane, BorderLayout.CENTER);
-    
+
     final JLabel title = new JLabel(name());
     title.setFont(LafService.font(LafService.FontToken.SEMIBOLD));
     title.setIcon(icon());
     add(title, BorderLayout.NORTH);
-    
+
     sideBarController.registerTreeView(this);
   }
 
@@ -151,14 +151,26 @@ public abstract class AbstractTreeView
     Optional
         .ofNullable(treePathsByLeaf.get(entity))
         .ifPresent(path -> {
+          requestVisibility();
           selectEntryInternal(path);
           eventPublisher.publishEvent(new BreadCrumbsChanged(path));
         });
   }
 
   protected void selectEntryInternal(TreePath path) {
+    final var oldSelection = tree.getSelectionPath();
+    // If the tree was previously hidden, and now a select brings it to fore, but the selection path
+    // effectively does not change, the selection listener won't be triggered. But we are counting
+    // on the selection listener to emit an event which results in views to be shown according to
+    // the selected node entity:
+    final var needsReselect = oldSelection != null && oldSelection.equals(path);
+
     tree.setSelectionPath(path);
     tree.scrollPathToVisible(path);
+    final Object terminal = path.getLastPathComponent();
+    if (needsReselect && propagate && entityNodeType().isInstance(terminal)) {
+      eventPublisher.publishEvent(terminal);
+    }
   }
 
   @Override
@@ -166,6 +178,11 @@ public abstract class AbstractTreeView
     propagate = false;  // FIXME: This is a freaking hack!
     selectNode(entity);
     propagate = true;
+  }
+
+  @Override
+  public void clearSelection() {
+    tree.clearSelection();
   }
 
   @Override

--- a/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/tree/TreeView.java
+++ b/swing/src/main/java/com/aestallon/storageexplorer/swing/ui/tree/TreeView.java
@@ -48,6 +48,8 @@ public interface TreeView<ENTITY, USER_DATA_CHANGE_EVENT> {
 
   void selectNodeSoft(final DefaultMutableTreeNode node);
 
+  void clearSelection();
+
   void removeStorage(final StorageInstance storageInstance);
 
   void onUserDataChanged(final USER_DATA_CHANGE_EVENT userDataChangeEvent);


### PR DESCRIPTION
fix another quirk, where if an inspector/script view is selected through `FindTabDialog`, where the view belonged to a hidden tree, which had the stale selection of that exact view, then the FindTab action would trigger the tree and breadcrumb changes, but not show the view itself